### PR TITLE
Mac OSX Compile Fixes

### DIFF
--- a/README-OSX.md
+++ b/README-OSX.md
@@ -1,0 +1,16 @@
+Build instructions for OSX
+--------------------------
+Builds on OSX have been tested with brew packages.
+
+To Compile, make sure you have the necessary packages installed:
+```bash
+$ brew install cmake openssl doxygen
+$ git clone https://github.com/Z-WavePublic/libzwaveip.git
+$ cd libzwaveip
+$ mkdir build
+$ cmake -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl/ -DOPENSSL_LIBRARIES=/usr/local/opt/openssl/lib/ ..
+$ make
+```
+
+You need to supply the path to the copy of openssl installed with brew, as the default openssl library on OSX is not compatible. 
+

--- a/README.md
+++ b/README.md
@@ -36,19 +36,3 @@ To test the reference_client, make sure the zipgateway is running and connect to
 See section "Working with the Reference Z/IP client" in [this guide](http://zwavepublic.com/developer)
 for instructions on using the reference_client.
 
-Build instructions for OSX
---------------------------
-Builds on OSX have been tested with brew packages.
-
-To Compile, make sure you have the necessary packages installed:
-```bash
-$ brew install cmake openssl doxygen
-$ git clone https://github.com/Z-WavePublic/libzwaveip.git
-$ cd libzwaveip
-$ mkdir build
-$ cmake -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl/ -DOPENSSL_LIBRARIES=/usr/local/opt/openssl/lib/ ..
-$ make
-```
-
-You need to supply the path to the copy of openssl installed with brew, as the default openssl library on OSX is not compatible. 
-

--- a/README.md
+++ b/README.md
@@ -35,3 +35,20 @@ To test the reference_client, make sure the zipgateway is running and connect to
 
 See section "Working with the Reference Z/IP client" in [this guide](http://zwavepublic.com/developer)
 for instructions on using the reference_client.
+
+Build instructions for OSX
+--------------------------
+Builds on OSX have been tested with brew packages.
+
+To Compile, make sure you have the necessary packages installed:
+```bash
+$ brew install cmake openssl doxygen
+$ git clone https://github.com/Z-WavePublic/libzwaveip.git
+$ cd libzwaveip
+$ mkdir build
+$ cmake -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl/ -DOPENSSL_LIBRARIES=/usr/local/opt/openssl/lib/ ..
+$ make
+```
+
+You need to supply the path to the copy of openssl installed with brew, as the default openssl library on OSX is not compatible. 
+

--- a/examples/reference_apps/CMakeLists.txt
+++ b/examples/reference_apps/CMakeLists.txt
@@ -9,8 +9,12 @@ add_executable(reference_client reference_client.c tokenizer.c
   hexchar.c command_completion.c util.c tokquote/tokquote.c)
 add_executable(reference_listener reference_listener.c util.c)
 
-target_link_libraries(reference_client zwaveip edit parse_xml xml2 zw_cmd_tool -lbsd -ltermcap ${MDNS_LIBS})
-target_link_libraries(reference_listener zwaveip parse_xml xml2)
+if (APPLE)
+target_link_libraries(reference_client zwaveip edit parse_xml xml2 zw_cmd_tool -ltermcap ${MDNS_LIBS} ${OPENSSL_LIBRARIES})
+elseif(UNIX)
+target_link_libraries(reference_client zwaveip edit parse_xml xml2 zw_cmd_tool -lbsd -ltermcap ${MDNS_LIBS} ${OPENSSL_LIBRARIES})
+endif ()
+target_link_libraries(reference_listener zwaveip parse_xml xml2 ${OPENSSL_LIBRARIES})
 
 add_custom_command(TARGET reference_client PRE_BUILD COMMAND ${CMAKE_COMMAND} -E copy_directory
 	${CMAKE_SOURCE_DIR}/config $<TARGET_FILE_DIR:reference_client>)

--- a/examples/reference_apps/command_completion.c
+++ b/examples/reference_apps/command_completion.c
@@ -145,7 +145,7 @@ int static parse_token(const char* token) {
     case DESTINATION: {
       rl_basic_word_break_characters = "\"";
       rl_quote_completion = 1;
-      struct zip_service* s = zresource_services;
+      struct zip_service* s = zresource_get();
       for (; s; s = s->next) {
         if (strcmp(s->service_name, token) == 0) {
           parser.state = COMMAND_CLASS;
@@ -271,7 +271,7 @@ static char* operation_generator(const char* text, int state) {
       }
       break;
     case DESTINATION: {
-      struct zip_service* s = zresource_services;
+      struct zip_service* s = zresource_get();
       int n = 0;
       char buf[512];
 

--- a/examples/reference_apps/reference_client.c
+++ b/examples/reference_apps/reference_client.c
@@ -436,7 +436,7 @@ static void cmd_send(const char *input) {
     service_name++;                             /* strip opening quote */
     service_name[strlen(service_name) - 1] = 0; /* strip closing quote */
   }
-  for (n = zresource_services; n; n = n->next) {
+  for (n = zresource_get(); n; n = n->next) {
     if (0 == strcmp(n->service_name, service_name)) {
       const char *result;
       /* Try connecting via IPv6 first */
@@ -484,7 +484,7 @@ static void cmd_list_service(void) {
   ;
 
   printf("List of discovered Z/IP services:\n");
-  for (n = zresource_services; n; n = n->next) {
+  for (n = zresource_get(); n; n = n->next) {
     printf("--- %20s: \"%s\"\n", n->host_name, n->service_name);
   }
 }

--- a/include/zresource.h
+++ b/include/zresource.h
@@ -90,18 +90,16 @@ struct zip_service
 };
 
 /**
- * First elemnets in a linked list of Z/IP services
+ * get a linked list of Z/IP services
  *
  * The list may be iterated like this
  * @code{.c}
  * struct zip_service* n;;
- * for(n = zresource_services; n ; n=n->next) {
+ * for(n = zresource_get(); n ; n=n->next) {
  *  ...
  * }
  * @endcode
  */
-//extern struct zip_service* zresource_services;
-
 struct zip_service* zresource_get();
 
 /**

--- a/include/zresource.h
+++ b/include/zresource.h
@@ -100,7 +100,9 @@ struct zip_service
  * }
  * @endcode
  */
-extern struct zip_service* zresource_services;
+//extern struct zip_service* zresource_services;
+
+struct zip_service* zresource_get();
 
 /**
  * Thread function of the mdns listner. This is the main loop of the mdns thread. This should normally be run

--- a/libedit/config.h
+++ b/libedit/config.h
@@ -32,7 +32,11 @@
 
 /* Define to 1 if you have getpwnam_r and getpwuid_r that are POSIX.1
    compatible. */
+#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
+#undef HAVE_GETPW_R_POSIX
+#else
 #define HAVE_GETPW_R_POSIX 1
+#endif
 
 /* Define to 1 if you have the <inttypes.h> header file. */
 #define HAVE_INTTYPES_H 1

--- a/libedit/config.h
+++ b/libedit/config.h
@@ -32,7 +32,7 @@
 
 /* Define to 1 if you have getpwnam_r and getpwuid_r that are POSIX.1
    compatible. */
-#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
+#if (defined(__APPLE__) && defined(__MACH__))
 #undef HAVE_GETPW_R_POSIX
 #else
 #define HAVE_GETPW_R_POSIX 1

--- a/libedit/history.c
+++ b/libedit/history.c
@@ -48,7 +48,11 @@ __RCSID("$NetBSD: history.c,v 1.57 2016/04/11 18:56:31 christos Exp $");
 #include <stdarg.h>
 #include <stdlib.h>
 #include <string.h>
+#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
+#include <vis.h>
+#else
 #include <bsd/vis.h>
+#endif
 
 static const char hist_cookie[] = "_HiStOrY_V2_\n";
 

--- a/libedit/history.c
+++ b/libedit/history.c
@@ -48,7 +48,7 @@ __RCSID("$NetBSD: history.c,v 1.57 2016/04/11 18:56:31 christos Exp $");
 #include <stdarg.h>
 #include <stdlib.h>
 #include <string.h>
-#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
+#if (defined(__APPLE__) && defined(__MACH__))
 #include <vis.h>
 #else
 #include <bsd/vis.h>

--- a/libedit/readline.c
+++ b/libedit/readline.c
@@ -48,8 +48,11 @@ __RCSID("$NetBSD: readline.c,v 1.138 2016/09/01 13:23:44 mbalmer Exp $");
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
+#include <vis.h>
+#else
 #include <bsd/vis.h>
-
+#endif
 #include "readline/readline.h"
 #include "el.h"
 #include "fcns.h"

--- a/libedit/readline.c
+++ b/libedit/readline.c
@@ -48,7 +48,7 @@ __RCSID("$NetBSD: readline.c,v 1.138 2016/09/01 13:23:44 mbalmer Exp $");
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
-#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
+#if (defined(__APPLE__) && defined(__MACH__))
 #include <vis.h>
 #else
 #include <bsd/vis.h>

--- a/libzwaveip/zresource.c
+++ b/libzwaveip/zresource.c
@@ -27,6 +27,11 @@
 #include <arpa/inet.h>
 struct zip_service* zresource_services;
 
+struct zip_service* zresource_get() {
+  return zresource_services;
+}
+
+
 struct zip_service* find_service(const char* name) {
   struct zip_service* n;
   for (n = zresource_services; n; n = n->next) {


### PR DESCRIPTION
This commit fixes up so it compiles cleanly on OSX. There are a few issues:
1) getpwent_r isn't present on OSX, as a result, libedit fails to compile. 
2) libbsd is not present (or required) on OSX, so the examples were not linking.
3) the refrence_listener was missing the openssl library in the linking.
4) zresource_services was being declared as a common symbol on Clang, and as failing during the linking process. Replace with a small function that returns a pointer to the zresource_services instead.

This is compile tested only, as I still lack a functioning zipgateway. 
