### PR TITLE
Remove unused trailing field in NODE_REMOVE command

### DIFF
--- a/examples/reference_apps/reference_client.c
+++ b/examples/reference_apps/reference_client.c
@@ -261,8 +261,7 @@ void cmd_remove_node(struct zconnection *zc) {
   buf[idx++] = NODE_REMOVE;
   buf[idx++] = get_unique_seq_no();
   buf[idx++] = 0;
-  buf[idx++] = 0x01; /* ADD_NODE_ANY */
-  buf[idx++] = 0;    /* Normal power, no NWI */
+  buf[idx++] = 0x01; /* REMOVE_NODE_ANY */
 
   zconnection_send_async(zc, buf, idx, 0);
 }


### PR DESCRIPTION
The unused field was appended as a copy-paste error from NODE_ADD.
Removing the field in accordance with SDS13784 and the older [SDS12652](http://zwavepublic.com/sites/default/files/SDS12652-13%20-%20Z-Wave%20Command%20Class%20Specification%20N-Z.pdf).

The extra byte is ignored by the Z/IP Gateway and the remove command works
in any case.

Change-Id: I48851723e3a17a67b94226ea0cb152c2ee24100b