### PR TITLE
Added command line option for the zwave command xml file

### DIFF
--- a/examples/reference_apps/reference_listener.c
+++ b/examples/reference_apps/reference_listener.c
@@ -27,12 +27,20 @@
 #include "libzwaveip.h"
 #include "parse_xml.h"
 #include "util.h"
+#include <limits.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+
+#ifndef DEFAULT_ZWAVE_CMD_CLASS_XML
+#define DEFAULT_ZWAVE_CMD_CLASS_XML "/usr/local/share/zwave/ZWave_custom_cmd_classes.xml"
+#endif
 
 struct app_config {
   uint8_t psk[64];
   uint8_t psk_len;
   char listen_ip[200]; /* longest wellformed ipv6 text encoded is 39 bytes
                           long, this should suffice */
+  char xml_file_path[PATH_MAX];
   uint16_t listen_port;
 } cfg;
 
@@ -68,7 +76,7 @@ static void print_usage(void) {
   printf("\n");
   printf(
       "Usage: reference_listner -l <IP address of interface to listen on> [-p "
-      "PSK] [-o Port] \n");
+      "PSK] [-o Port] [-x <zwave_xml_file>] \n");
   printf("\n");
   printf("NOTE: IP address can be both IPv4 or IPv6\n");
   printf("for example \n");
@@ -113,16 +121,27 @@ void parse_listen_port(struct app_config *cfg, char *optarg) {
     cfg->listen_port = atoi(optarg);
 
 }
+
+void parse_xml_filename(struct app_config *cfg, char *optarg) {
+  struct stat _stat;
+  if (!stat(optarg, &_stat)) {
+    strcpy(cfg->xml_file_path, optarg);
+  }
+}
+
 static void parse_prog_args(int prog_argc, char **prog_argv) {
   int opt;
 
-  while ((opt = getopt(prog_argc, prog_argv, "p:l:o:")) != -1) {
+  while ((opt = getopt(prog_argc, prog_argv, "p:l:o:x:")) != -1) {
     switch (opt) {
       case 'p':
         parse_psk(&cfg, optarg);
         break;
       case 'l':
         parse_listen_ip(&cfg, optarg);
+        break;
+      case 'x':
+        parse_xml_filename(&cfg, optarg);
         break;
       case 'o':
         parse_listen_port(&cfg, optarg); 
@@ -143,7 +162,18 @@ int main(int argc, char **argv) {
   parse_prog_args(argc, argv);
 
   if (strlen(cfg.listen_ip) > 0) {
-    xml_filename = find_xml_file(argv[0]);
+    if (!*cfg.xml_file_path) {
+      // no user specified file - look for the default file in /etc/zipgateway.d
+      parse_xml_filename(&cfg, DEFAULT_ZWAVE_CMD_CLASS_XML);
+    }
+    if (*cfg.xml_file_path) {
+      // use the user specified file, or the default if it was found in the expected location
+      xml_filename = cfg.xml_file_path;
+    } else {
+      // fallback to looking in the same directory where the binary is located
+      xml_filename = find_xml_file(argv[0]);
+    }
+
     if (!initialize_xml(xml_filename)) {
       printf("Could not load Command Class definitions\n");
       return -1;


### PR DESCRIPTION
In the case that someone wants to build and install the reference tools on a device as debug tools, and maybe place the binaries in the /usr/local/bin directory, it is undesirable to also place the XML file in the bin directory. 

This patch allows the XML file to be specified on the command line with the -x switch. If the switch is not specified it will fall back to a pre-defined location (which can be set in the CMakeList.txt files if desired). If the file is not found in that location it will fall back to the existing behavior of looking in the same directory as the binary.
