### PR TITLE
Add FreeBSD platform

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,25 +4,27 @@ cmake_minimum_required(VERSION 2.9)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/")
 
 #add_definitions(-Wall -Werror)
-set(CMAKE_C_FLAGS "-std=gnu99")
+#set(CMAKE_C_FLAGS "-std=gnu99")
+set(CMAKE_C_FLAGS "-std=gnu99 -g -DDEBUG")
 
 find_package(OpenSSL REQUIRED 1.0.1)
 
 find_library(AVAHI_LIBRARY-COMMON NAMES avahi-common)
 find_library(AVAHI_LIBRARY-CLIENT NAMES avahi-client)
+find_path(AVAHI_CLIENT_INCLUDE_DIR avahi-client/client.h)
 
 if(AVAHI_LIBRARY-CLIENT)
   add_definitions(-DWITH_MDNS)
   set(MDNS_LIBS ${AVAHI_LIBRARY-COMMON} ${AVAHI_LIBRARY-CLIENT})
 endif()
 
-include_directories(include/ ${OPENSSL_INCLUDE_DIR} xml/ libedit/) 
+find_package(LibXml2)
+
+include_directories(include/ ${OPENSSL_INCLUDE_DIR} ${AVAHI_CLIENT_INCLUDE_DIR} ${LIBXML_INCLUDE_DIR} xml/ libedit/)
 add_subdirectory( libzwaveip )
 add_subdirectory( xml )
 add_subdirectory( libedit )
 add_subdirectory( examples )
-
-find_package(LibXml2)
 
 find_package(Doxygen)
 IF (NOT DOXYGEN_FOUND)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,8 +4,7 @@ cmake_minimum_required(VERSION 2.9)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/")
 
 #add_definitions(-Wall -Werror)
-#set(CMAKE_C_FLAGS "-std=gnu99")
-set(CMAKE_C_FLAGS "-std=gnu99 -g -DDEBUG")
+set(CMAKE_C_FLAGS "-std=gnu99")
 
 find_package(OpenSSL REQUIRED 1.0.1)
 

--- a/examples/reference_apps/CMakeLists.txt
+++ b/examples/reference_apps/CMakeLists.txt
@@ -3,18 +3,21 @@ add_subdirectory( tokquote )
 # place binaries in top-level build folder
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 
-include_directories( ${PROJECT_SOURCE_DIR}  )
+find_package(LibXml2)
+include_directories(${PROJECT_SOURCE_DIR} ${LIBXML2_INCLUDE_DIR})
+get_filename_component(LIBXML2_LIBRARY_DIR ${LIBXML2_LIBRARIES} DIRECTORY)
+link_directories(${LIBXML2_LIBRARY_DIR})
 
 add_executable(reference_client reference_client.c tokenizer.c
-  hexchar.c command_completion.c util.c tokquote/tokquote.c)
+    hexchar.c command_completion.c util.c tokquote/tokquote.c)
 add_executable(reference_listener reference_listener.c util.c)
 
-if (APPLE)
+if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin" OR ${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")
 target_link_libraries(reference_client zwaveip edit parse_xml xml2 zw_cmd_tool -ltermcap ${MDNS_LIBS} ${OPENSSL_LIBRARIES})
-elseif(UNIX)
+elseif(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 target_link_libraries(reference_client zwaveip edit parse_xml xml2 zw_cmd_tool -lbsd -ltermcap ${MDNS_LIBS} ${OPENSSL_LIBRARIES})
 endif ()
 target_link_libraries(reference_listener zwaveip parse_xml xml2 ${OPENSSL_LIBRARIES})
 
 add_custom_command(TARGET reference_client PRE_BUILD COMMAND ${CMAKE_COMMAND} -E copy_directory
-	${CMAKE_SOURCE_DIR}/config $<TARGET_FILE_DIR:reference_client>)
+    ${CMAKE_SOURCE_DIR}/config $<TARGET_FILE_DIR:reference_client>)

--- a/include/zresource.h
+++ b/include/zresource.h
@@ -23,6 +23,9 @@
 #ifndef ZRESOURCE_H_
 #define ZRESOURCE_H_
 
+#include <sys/types.h>
+#include <sys/socket.h>
+
 #include <stdint.h>
 #include <netinet/in.h>
 #include <netinet/ip6.h>

--- a/libedit/history.c
+++ b/libedit/history.c
@@ -48,7 +48,7 @@ __RCSID("$NetBSD: history.c,v 1.57 2016/04/11 18:56:31 christos Exp $");
 #include <stdarg.h>
 #include <stdlib.h>
 #include <string.h>
-#if (defined(__APPLE__) && defined(__MACH__))
+#if (defined(__APPLE__) && defined(__MACH__)) || defined(__FreeBSD__)
 #include <vis.h>
 #else
 #include <bsd/vis.h>

--- a/libedit/readline.c
+++ b/libedit/readline.c
@@ -48,7 +48,7 @@ __RCSID("$NetBSD: readline.c,v 1.138 2016/09/01 13:23:44 mbalmer Exp $");
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
-#if (defined(__APPLE__) && defined(__MACH__))
+#if (defined(__APPLE__) && defined(__MACH__)) || defined(__FreeBSD__)
 #include <vis.h>
 #else
 #include <bsd/vis.h>

--- a/libzwaveip/avahi-mdns.c
+++ b/libzwaveip/avahi-mdns.c
@@ -24,6 +24,7 @@
 #include <assert.h>
 #include <stdlib.h>
 #include <time.h>
+#include <sys/socket.h>
 #include <avahi-client/client.h>
 #include <avahi-client/lookup.h>
 #include <avahi-common/simple-watch.h>

--- a/libzwaveip/libzwaveip.c
+++ b/libzwaveip/libzwaveip.c
@@ -508,7 +508,9 @@ void *connection_handle(void *info) {
 
   pinfo->is_running = 1;
 
+  pthread_mutex_lock(&pinfo->handshake_mutex);
   pthread_cond_signal(&pinfo->handshake_cond);
+  pthread_mutex_unlock(&pinfo->handshake_mutex);
 
   while (!(SSL_get_shutdown(ssl) & SSL_RECEIVED_SHUTDOWN) &&
          num_timeouts < max_timeouts && pinfo->is_running) {
@@ -744,7 +746,10 @@ struct zconnection *zclient_start(const char *remote_address, uint16_t port,
   }
 #endif
 
+  pthread_mutex_lock(&info->handshake_mutex);
   pthread_cond_wait(&info->handshake_cond, &info->handshake_mutex);
+  pthread_mutex_unlock(&info->handshake_mutex);
+
   if (info->is_running) {
     return &info->connection;
   }

--- a/xml/CMakeLists.txt
+++ b/xml/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_subdirectory( test )
 include_directories( . )
-include_directories( "/usr/include/libxml2/" )
+include_directories(${LIBXML2_INCLUDE_DIR})
 
 include(FindPythonInterp)
 find_package(LibXml2)

--- a/xml/test/CMakeLists.txt
+++ b/xml/test/CMakeLists.txt
@@ -1,5 +1,8 @@
-include_directories( "/usr/include/libxml2/" )
 find_package(LibXml2)
+include_directories(${LIBXML2_INCLUDE_DIR})
+get_filename_component(LIBXML2_LIBRARY_DIR ${LIBXML2_LIBRARIES} DIRECTORY)
+link_directories(${LIBXML2_LIBRARY_DIR})
+
 add_executable( test_parse_xml test_parse_xml.c )
 target_link_libraries( test_parse_xml parse_xml xml2 )
 configure_file(${CMAKE_SOURCE_DIR}/config/ZWave_custom_cmd_classes.xml ${CMAKE_CURRENT_BINARY_DIR})


### PR DESCRIPTION
Builds libzwaveip under FreeBSD.
Builds reference_client and reference_listener under FreeBSD.
Corrects some undefined behavior with mutexes that resulted in non-working applications under FreeBSD.

Tested under FreeBSD 11.0 and Debian 8.2 to verify that the Linux build wasn't broken.