### PR TITLE
Add Debug and Release build types

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,8 +3,23 @@ cmake_minimum_required(VERSION 2.9)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/")
 
+# Enforce build type
+if(NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE Release CACHE STRING "Build type, options are: Debug Release." FORCE)
+endif()
+
 #add_definitions(-Wall -Werror)
-set(CMAKE_C_FLAGS "-std=gnu99")
+set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS} -std=gnu99 -O1 -g -DDEBUG=1")
+if("${CMAKE_C_COMPILER_ID}" STREQUAL "Clang")
+  # Use Address Sanitizer for Debug builds when using Clang
+  set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -fsanitize=address -fno-omit-frame-pointer")
+elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+  # Use FORTIFY_SOURCE for Debug builds when using GCC
+  set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -D_FORTIFY_SOURCE=2")
+endif()
+set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS} -std=gnu99 -Os")
+set(CMAKE_STATIC_LINKER_FLAGS_RELEASE "${CMAKE_EXE_LINKER_FLAGS} -s")
+set(CMAKE_EXE_LINKER_FLAGS_RELEASE "${CMAKE_EXE_LINKER_FLAGS} -s")
 
 find_package(OpenSSL REQUIRED 1.0.1)
 

--- a/xml/CMakeLists.txt
+++ b/xml/CMakeLists.txt
@@ -5,12 +5,14 @@ include_directories(${LIBXML2_INCLUDE_DIR})
 include(FindPythonInterp)
 find_package(LibXml2)
 
-# Using gnu99 instead of c99 to get strdup(3)
-set(CMAKE_C_FLAGS "-std=gnu99")
+if(NOT CMAKE_C_FLAGS)
+  # Using gnu99 instead of c99 to get strdup(3)
+  set(CMAKE_C_FLAGS "-std=gnu99")
+endif()
 
-add_custom_command(OUTPUT zw_gen_hdr.c 
+add_custom_command(OUTPUT zw_gen_hdr.c
   COMMAND ${PYTHON_EXECUTABLE} generate_c_decoder.py  > ${CMAKE_CURRENT_BINARY_DIR}/zw_gen_hdr.c
-  DEPENDS generate_c_decoder.py ../config/ZWave_custom_cmd_classes.xml 
+  DEPENDS generate_c_decoder.py ../config/ZWave_custom_cmd_classes.xml
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
 


### PR DESCRIPTION
Small additions to CMakeLists.txt to add a "Release" build type (used as the default build type) and a "Debug" build type. Release builds add -Os (-O2) optimizations to the previous flags, and strip the resulting build objects. Debug builds add debug symbols, set the DEBUG flag, and add some memory debugging helpers.