### PR TITLE
Fix #58 - Commands history not being saved when libzwaveip restarts

### DIFF
--- a/examples/reference_apps/command_completion.h
+++ b/examples/reference_apps/command_completion.h
@@ -35,4 +35,7 @@ void initialize_completer(void);
  */
 void completer_restart(void);
 
+/* Stop the command completer and save the history. */
+void stop_completer(void);
+
 #endif /* COMMAND_COMPLETION_H_ */

--- a/examples/reference_apps/reference_client.c
+++ b/examples/reference_apps/reference_client.c
@@ -769,6 +769,7 @@ int main(int argc, char **argv) {
 
     // Check for EOF.
     if (!input) {
+      stop_completer();
       break;
     }
 
@@ -783,6 +784,7 @@ int main(int argc, char **argv) {
     free(input);
 
     if (!running) {
+      stop_completer();
       break;
     }
   }


### PR DESCRIPTION
Write the commands history when libzwaveip is getting stopped.